### PR TITLE
feat: add credentials to fetch fn

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,17 @@ const nextConfig: NextConfig = {
   images: {
     unoptimized: true,
   },
+  async rewrites() {
+    if (!isProd) {
+      return [
+        {
+          source: "/api/:path*",
+          destination: "https://guangfu250923.pttapp.cc/:path*",
+        },
+      ];
+    }
+    return [];
+  },
 };
 
 export default nextConfig;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,10 +1,13 @@
 const API_BASE_URL = "https://guangfu250923.pttapp.cc";
+const isProd = process.env.NODE_ENV === "production";
 
 export async function fetchAPI<T>(
   endpoint: string,
   params?: Record<string, string | number>
 ): Promise<T> {
-  const url = new URL(`${API_BASE_URL}${endpoint}`);
+  const base = isProd ? API_BASE_URL : `${window.location.origin}/api`; // dev should have /api for proxy
+  const path = endpoint.startsWith("/") ? endpoint : `/${endpoint}`;
+  const url = new URL(`${base}${path}`);
 
   if (params) {
     Object.entries(params).forEach(([key, value]) => {
@@ -12,7 +15,13 @@ export async function fetchAPI<T>(
     });
   }
 
-  const response = await fetch(url.toString());
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+  });
 
   if (!response.ok) {
     throw new Error(`API Error: ${response.status} ${response.statusText}`);
@@ -346,17 +355,23 @@ export interface ReportResponse {
   updated_at: number;
 }
 
-export async function submitReport(data: ReportRequest): Promise<ReportResponse> {
-  const response = await fetch(`${API_BASE_URL}/reports`, {
-    method: 'POST',
+export async function submitReport(
+  data: ReportRequest
+): Promise<ReportResponse> {
+  const base = isProd ? API_BASE_URL : `${window.location.origin}/api`; // dev should have /api for proxy
+  const url = `${base}/reports`;
+
+  const response = await fetch(url, {
+    method: "POST",
     headers: {
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
     },
+    credentials: "include",
     body: JSON.stringify(data),
   });
 
   if (!response.ok) {
-    throw new Error('提交失敗,請稍後再試');
+    throw new Error("提交失敗，請稍後再試");
   }
 
   return response.json();


### PR DESCRIPTION
## Summary
  Add API proxy configuration for development environment and fix production fetch requests with
  credentials

  ## Changes
  - **API Proxy**: Added `rewrites` configuration in `next.config.ts` to proxy `/api/*` requests to
   `https://guangfu250923.pttapp.cc/` during development
  - **Fetch Credentials**: Updated all API fetch requests to include `credentials: 'include'` for
  proper cookie/session handling

  ## Technical Details
  The proxy configuration conditionally routes API requests based on environment:
  - **Development**: Routes `/api/:path*` → `https://guangfu250923.pttapp.cc/:path*`
  - **Production**: No rewrites applied

  All fetch calls in `src/utils/api.ts` now include `credentials: 'include'` to ensure cookies are
  sent with cross-origin requests.

  ## Test Plan
  - [ ] Verify API requests work correctly in development environment
  - [ ] Confirm authentication cookies are properly sent with requests
  - [ ] Test production build with direct API calls